### PR TITLE
The attachment upload api expects a document

### DIFF
--- a/lib/rubill/attachment.rb
+++ b/lib/rubill/attachment.rb
@@ -6,7 +6,7 @@ module Rubill
       Query.upload_attachment({
         id: object_id,
         fileName: file_name,
-        content: content
+        document: content
       })
     end
 

--- a/spec/attachment_spec.rb
+++ b/spec/attachment_spec.rb
@@ -13,7 +13,7 @@ module Rubill
           expect(Query).to receive(:upload_attachment).with({
             id: id,
             fileName: file_name,
-            content: 'Test text'
+            document: 'Test text'
           })
         end
 


### PR DESCRIPTION
- this was causing an invalid document error when uploading