### PR TITLE
Add content key back to attachments

### DIFF
--- a/lib/rubill/attachment.rb
+++ b/lib/rubill/attachment.rb
@@ -6,7 +6,8 @@ module Rubill
       Query.upload_attachment({
         id: object_id,
         fileName: file_name,
-        document: content
+        document: content,
+        content: content
       })
     end
 

--- a/spec/attachment_spec.rb
+++ b/spec/attachment_spec.rb
@@ -13,7 +13,8 @@ module Rubill
           expect(Query).to receive(:upload_attachment).with({
             id: id,
             fileName: file_name,
-            document: 'Test text'
+            document: 'Test text',
+            content: 'Test text'
           })
         end
 


### PR DESCRIPTION
- this is a result of some odd behavior from the bill.com api
- yesterday when adding a document without the `document` key, I got an
`invalid document` error, which was corrected by adding the document
key.  Confirmed that the document then showed up in the bill.com
sandbox.  Today if I upload with the document key, I do not receive an
error, but I end up with an empty document.  As it stands today we drop
the document key, but I'm hesitant to do so given that only yesterday
the api was seemingly changed without warning to require the `document`
key in lieu of `content`.